### PR TITLE
Changed height of nav div to h-fit

### DIFF
--- a/src/ui/MainNav/MainNavCoreContentGroup.astro
+++ b/src/ui/MainNav/MainNavCoreContentGroup.astro
@@ -58,7 +58,7 @@ const bgPosY = `${(bgImage.hotspot?.y ?? 0) * 100}%`;
     <div
       class:list={[
         "fixed inset-0 bg-orange-50",
-        "lg:absolute lg:top-full lg:h-fit xl:mx-6 2xl:container 2xl:mx-auto",
+        "lg:absolute lg:top-full lg:h-[75vh] xl:mx-6 2xl:container 2xl:mx-auto",
         "lg:shadow-2xl",
       ]}
     >

--- a/src/ui/MainNav/MainNavCoreContentGroup.astro
+++ b/src/ui/MainNav/MainNavCoreContentGroup.astro
@@ -58,7 +58,7 @@ const bgPosY = `${(bgImage.hotspot?.y ?? 0) * 100}%`;
     <div
       class:list={[
         "fixed inset-0 bg-orange-50",
-        "lg:absolute lg:top-full lg:h-[800px] xl:mx-6 2xl:container 2xl:mx-auto",
+        "lg:absolute lg:top-full lg:h-fit xl:mx-6 2xl:container 2xl:mx-auto",
         "lg:shadow-2xl",
       ]}
     >

--- a/src/ui/SiteHeader.astro
+++ b/src/ui/SiteHeader.astro
@@ -31,7 +31,7 @@ const lightUrl = `url(${lightHeaderLogo?.url})`;
 const darkUrl = `url(${darkHeaderLogo?.url})`;
 ---
 
-<div class="w-screen bg-yellow-200">
+<div class="w-full bg-yellow-200">
   <nav class="flex justify-end xl:container xl:mx-auto">
     <a
       class:list={[


### PR DESCRIPTION
#### Changes:
- changed height of navigation div from `lg:h-[800px]` to `lg:h-fit`

![image](https://github.com/user-attachments/assets/ff3a341d-c8c0-4a68-ad41-63a9996b5f9c)

I realize that this change does not specifically create `8rem` space as requested, but I think this may be a cleaner solution to the problem while still ensuring there is enough click away space at the bottom. Let me know what you think!

## Edit:
#### Changes
- changed the width of site header from `w-screen` to `w-full` to remove unnecessary horizontal scrollbar
- made height of nav panel take only 75% of the viewport height

![image](https://github.com/user-attachments/assets/edd0f591-7f6e-48a9-a0fb-04056d2e531a)


Closes #63 