### PR TITLE
Improved category photo presentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto

--- a/src/ui/PageHeader.astro
+++ b/src/ui/PageHeader.astro
@@ -3,6 +3,7 @@ import { getFallbackImageCollection, getImageUrlBuilder } from "@common/client";
 import { wgmDesignSystem as ds } from "@common/design-system";
 import type { PageTitle } from "@common/page";
 import type { SanityImage } from "@model/image";
+import Container from "./primitives/Container.astro";
 
 interface Props {
   pageTitle: PageTitle;
@@ -18,103 +19,75 @@ const image =
   fallbackImages[Math.floor(Math.random() * fallbackImages.length)];
 
 const smImgUrl = image
-  ? `url(${getImageUrlBuilder(image.image).width(640).height(320).url()})`
+  ? getImageUrlBuilder(image.image).width(640).height(320).url()
   : null;
 const mdImgUrl = image
-  ? `url(${getImageUrlBuilder(image.image).width(1024).height(512).url()})`
+  ? getImageUrlBuilder(image.image).width(1024).height(512).url()
   : null;
 const lgImgUrl = image
-  ? `url(${getImageUrlBuilder(image.image).width(1280).height(640).url()})`
+  ? getImageUrlBuilder(image.image).width(1280).height(640).url()
   : null;
 const xlImgUrl = image
-  ? `url(${getImageUrlBuilder(image.image).width(2560).height(850).url()})`
+  ? getImageUrlBuilder(image.image).width(1400).height(650).url()
   : null;
-const bgPosX = `${(image.image.hotspot?.x ?? 0) * 100}%`;
-const bgPosY = `${(image.image.hotspot?.y ?? 0) * 100}%`;
 ---
 
 <header class={ds.background.color.neutral.defaultLighter}>
-  <div class:list={["sm:mx-auto sm:p-3 sm:relative", "xl:container xl:p-6"]}>
-    <div class:list={["sm:bg-white sm:p-2 sm:shadow-xl", "xl:mx-6", "lg:mt-6"]}>
-      <div class:list={["page-header-bg", "h-40 sm:h-80 xl:h-96"]}></div>
-    </div>
-    <h1
-      class:list={[
-        "overflow-hidden",
-        "-mt-9",
-        "sm:mx-12 sm:absolute sm:bottom-0 sm:left-0",
-        "md:mx-24",
-        // "lg:top-0 lg:mt-8",
-        "xl:max-w-2xl ",
-      ]}
-    >
-      {
-        props.pageTitle.supTitle && (
-          <span class="block">
-            <span
-              class:list={[
-                "font-serif italic",
-                "box-decoration-clone px-3",
-                ds.background.color?.primary.default,
-                ds.typography.color?.primary.contrast,
-              ]}
-            >
-              {props.pageTitle.supTitle}
+  <Container>
+    <div class:list={["p-3 relative", "xl:container xl:p-6"]}>
+        <img
+          srcset={`${smImgUrl} 640w, ${mdImgUrl} 1024w, ${lgImgUrl} 1280w, ${xlImgUrl} 1560w`}
+          sizes="(max-width: 640px) 640px, (max-width: 1024px) 1024px, (max-width: 1280px) 1280px, 1560px"
+          class:list={["inline-block border-8 border-white drop-shadow-md"]}
+        />
+      <h1
+        class:list={[
+          "overflow-visible",
+          "absolute",
+          "-mt-12 sm:-mt-9",
+          "mx-4 sm:mx-12 md:bottom-0 md:left-0",
+          "md:mx-24",
+          "xl:max-w-2xl ",
+        ]}
+      >
+        {
+          props.pageTitle.supTitle && (
+            <span class="block">
+              <span
+                class:list={[
+                  "font-serif italic",
+                  "box-decoration-clone px-3 text-xs sm:text-sm md:text-lg lg:text-xl xl:text-2xl",
+                  ds.background.color?.primary.default,
+                  ds.typography.color?.primary.contrast,
+                ]}
+              >
+                {props.pageTitle.supTitle}
+              </span>
             </span>
-          </span>
-        )
-      }
+          )
+        }
 
-      <span class="block">
-        <span
-          class:list={[
-            "text-3xl font-serif font-medium lg:text-4xl",
-            "box-decoration-clone px-3",
-            ds.background.color?.primary.default,
-            ds.typography.color?.primary.contrast,
-          ]}
-        >
-          {props.pageTitle.title}
+        <span class="block">
+          <span
+            class:list={[
+              "text-2xl font-serif font-medium lg:text-4xl sm:text-2xl md:text-3xl",
+              "box-decoration-clone px-3",
+              ds.background.color?.primary.default,
+              ds.typography.color?.primary.contrast,
+            ]}
+          >
+            {props.pageTitle.title}
+          </span>
         </span>
-      </span>
 
-      {
-        props.pageTitle.subTitle && (
-          <span class="block">
-            <span>{props.pageTitle.subTitle}</span>
-          </span>
-        )
-      }
-    </h1>
-  </div>
+        {
+          props.pageTitle.subTitle && (
+            <span class="block">
+              <span>{props.pageTitle.subTitle}</span>
+            </span>
+          )
+        }
+      </h1>
+    </div>
+  </Container>
 </header>
-
-<style define:vars={{ smImgUrl, mdImgUrl, lgImgUrl, xlImgUrl, bgPosX, bgPosY }}>
-  .page-header-bg {
-    background-size: cover;
-    background-position: center;
-    background-position-x: var(--bgPosX);
-    background-position-y: var(--bgPosY);
-  }
-
-  @media (max-width: 640px) {
-    .page-header-bg {
-      background-image: var(--smImgUrl);
-    }
-  }
-  @media (min-width: 641px) and (max-width: 1024px) {
-    .page-header-bg {
-      background-image: var(--mdImgUrl);
-    }
-  }
-  @media (min-width: 1025px) and (max-width: 1280px) {
-    .page-header-bg {
-      background-image: var(--lgImgUrl);
-    }
-  }
-  @media (min-width: 1281px) {
-    .page-header-bg {
-      background-image: var(--xlImgUrl);
-    }
-  }
-</style>

--- a/src/ui/PageHeader.astro
+++ b/src/ui/PageHeader.astro
@@ -34,60 +34,53 @@ const xlImgUrl = image
 
 <header class={ds.background.color.neutral.defaultLighter}>
   <Container>
-    <div class:list={["p-3 relative", "xl:container xl:p-6"]}>
-        <img
-          srcset={`${smImgUrl} 640w, ${mdImgUrl} 1024w, ${lgImgUrl} 1280w, ${xlImgUrl} 1560w`}
-          sizes="(max-width: 640px) 640px, (max-width: 1024px) 1024px, (max-width: 1280px) 1280px, 1560px"
-          class:list={["inline-block border-8 border-white drop-shadow-md"]}
-        />
-      <h1
-        class:list={[
-          "overflow-visible",
-          "absolute",
-          "-mt-12 sm:-mt-9",
-          "mx-4 sm:mx-12 md:bottom-0 md:left-0",
-          "md:mx-24",
-          "xl:max-w-2xl ",
-        ]}
-      >
-        {
-          props.pageTitle.supTitle && (
-            <span class="block">
-              <span
-                class:list={[
-                  "font-serif italic",
-                  "box-decoration-clone px-3 text-xs sm:text-sm md:text-lg lg:text-xl xl:text-2xl",
-                  ds.background.color?.primary.default,
-                  ds.typography.color?.primary.contrast,
-                ]}
-              >
-                {props.pageTitle.supTitle}
-              </span>
-            </span>
-          )
-        }
-
-        <span class="block">
-          <span
-            class:list={[
-              "text-2xl font-serif font-medium lg:text-4xl sm:text-2xl md:text-3xl",
-              "box-decoration-clone px-3",
-              ds.background.color?.primary.default,
-              ds.typography.color?.primary.contrast,
-            ]}
-          >
-            {props.pageTitle.title}
-          </span>
-        </span>
-
-        {
-          props.pageTitle.subTitle && (
-            <span class="block">
-              <span>{props.pageTitle.subTitle}</span>
-            </span>
-          )
-        }
-      </h1>
+    <div class:list={["md:mx-3 md:m-8 md:p-3 md:bg-white md:shadow-lg"]}>
+      <img
+        srcset={`${smImgUrl} 640w, ${mdImgUrl} 1024w, ${lgImgUrl} 1280w, ${xlImgUrl} 1560w`}
+        sizes="(max-width: 640px) 640px, (max-width: 1024px) 1024px, (max-width: 1280px) 1280px, 100vw"
+        alt={image.altText}
+        src={xlImgUrl}
+      />
     </div>
+    <h1 class:list={["mx-3 -mt-8 md:mx-10 md:-mt-14 mb-3 md:mb-6"]}>
+      {
+        props.pageTitle.supTitle && (
+          <span class="block">
+            <span
+              class:list={[
+                "font-serif italic",
+                "box-decoration-clone px-3",
+                "lg:text-xl",
+                ds.background.color?.primary.default,
+                ds.typography.color?.primary.contrast,
+              ]}
+            >
+              {props.pageTitle.supTitle}
+            </span>
+          </span>
+        )
+      }
+
+      <span class="block">
+        <span
+          class:list={[
+            "text-3xl font-serif font-medium lg:text-4xl",
+            "box-decoration-clone px-3",
+            ds.background.color?.primary.default,
+            ds.typography.color?.primary.contrast,
+          ]}
+        >
+          {props.pageTitle.title}
+        </span>
+      </span>
+
+      {
+        props.pageTitle.subTitle && (
+          <span class="block">
+            <span>{props.pageTitle.subTitle}</span>
+          </span>
+        )
+      }
+    </h1>
   </Container>
 </header>


### PR DESCRIPTION
## Changes:
- Added `.gitattributes` file for normalizing line endings
- reduce width requested of `xl` image down to 1400 from 2560
- Used `Container` component to restrict header size
- Removed older css breakpoint code
- Added tailwind classes for better font scaling

## Screenshots (UPDATED):
#### XL:
![image](https://github.com/user-attachments/assets/0df23d75-0330-4561-948d-e4f6a2143eaf)

#### MD: 
![image](https://github.com/user-attachments/assets/c1245b7d-d186-4a4d-93fa-0c8cf803e009)

#### SM:
![image](https://github.com/user-attachments/assets/bb59a8da-ce3c-4fc1-826e-737e5d4e7279)

#### iPhone:
![image](https://github.com/user-attachments/assets/aeeb6da6-07b9-487f-961e-1ffb149be1e5)

Closes #70 