### PR TITLE
Update for 'contentBlock' migration

### DIFF
--- a/src/model/contentGroup.ts
+++ b/src/model/contentGroup.ts
@@ -8,13 +8,13 @@ import { zExtendedResourceType } from "./internetResource";
 export const gContentGroupProjection = groq`
   title,
   description,
-  "blocks": contentBlocks[]{
+  "blocks": coalesce(contentBlocks[]->{
     title,
     description,
     "content": content[]{
       ${gContentBlocksProjection}
     }
-  },
+  }, []),
   "jumpLink": coalesce(contentGroupJumpLink{
       "jumpLinkType": _type,
       label, 


### PR DESCRIPTION
'contentBlocks' field in 'contentGroup' has been migrated from an inline object to a referenced document so this updates the query to reflect that