### PR TITLE
improved text wrapping behaviour

### DIFF
--- a/src/styles/main.css
+++ b/src/styles/main.css
@@ -27,3 +27,9 @@
         format("woff-variations");
   }
 }
+
+@layer utilities {
+  .prose-balance p {
+    text-wrap: balance;
+  }
+}

--- a/src/ui/PortableTextContentBlock.astro
+++ b/src/ui/PortableTextContentBlock.astro
@@ -16,7 +16,7 @@ const htmlString = toHTML(props.portableText, {
 
 <div
   class:list={[
-    "prose prose-wgm font-serif max-w-none",
+    "prose prose-wgm font-serif max-w-none prose-balance",
     ...(props.classList ?? []),
   ]}
 >


### PR DESCRIPTION
Added a utility class to main.css to target the generated <p> tags in PortableContentBlock.astro.  I tried to use the tailwind equivalent directly in the class list of the <div> but it didn't work 