### PR TITLE
Displayed non-featured people differently 

### DIFF
--- a/src/pages/[person].astro
+++ b/src/pages/[person].astro
@@ -7,7 +7,7 @@ import MainLayout from "@layouts/MainLayout.astro";
 
 import Container from "@ui/primitives/Container.astro";
 import Heading from "@ui/primitives/Heading.astro";
-import PersonCard from "@ui/composites/PersonCard.astro";
+import FeaturedPerson from "@ui/composites/FeaturedPerson.astro";
 import PortableTextContentBlock from "@ui/typography/PortableTextContentBlock.astro";
 
 import type { Person } from "@model/person";
@@ -33,7 +33,7 @@ const props = Astro.props;
 <MainLayout>
   <Container>
     <div class="mt-3">
-      <PersonCard person={props.person} />
+      <FeaturedPerson person={props.person} />
     </div>
   </Container>
   <div class="bg-stone-100 p-4 py-6">

--- a/src/ui/PersonGroupBlock.astro
+++ b/src/ui/PersonGroupBlock.astro
@@ -33,11 +33,11 @@ const {
   }
   {showGroupDescription && <TextBlock>{personGroup.description}</TextBlock>}
   <div class:list={!featured ? [
-    "grid",
+    "grid gap-4",
     "sm:grid-cols-1",
     "md:grid-cols-2",
     "lg:grid-cols-3",
-    "gap-4"
+    "p-4"
   ] : []}>
     {
       featured ? 
@@ -55,7 +55,7 @@ const {
         ))
       :
       personGroup.members.map((person) => (
-        <Card disableBorder={true}>
+        <Card disableBorder={true} additiveClasses={["flex-1 p-4"]}>
           <PersonCard person={person} giveImportance={featured} />
         </Card>
       ))

--- a/src/ui/PersonGroupBlock.astro
+++ b/src/ui/PersonGroupBlock.astro
@@ -33,7 +33,7 @@ const {
   }
   {showGroupDescription && <TextBlock>{personGroup.description}</TextBlock>}
   <div class:list={!featured ? [
-    "grid gap-4",
+    "grid",
     "sm:grid-cols-1",
     "md:grid-cols-2",
     "lg:grid-cols-3",

--- a/src/ui/PersonGroupBlock.astro
+++ b/src/ui/PersonGroupBlock.astro
@@ -1,12 +1,12 @@
 ---
 import type { PersonGroup } from "@model/personGroup";
 import kebabCase from "lodash/kebabCase";
-import PersonCard from "./composites/PersonCard.astro";
+import FeaturedPerson from "./composites/FeaturedPerson.astro";
+import Person from "./composites/Person.astro";
 import EmphasizedEllipsisText from "./primitives/EmphasizedEllipsisText.astro";
 import Heading from "./primitives/Heading.astro";
 import Link from "./primitives/Link.astro";
 import TextBlock from "./typography/TextBlock.astro";
-import Card from "./primitives/Card.astro";
 
 interface Props {
   personGroup: PersonGroup;
@@ -43,7 +43,7 @@ const {
       featured ? 
         personGroup.members.map((person) => (
           <div>
-            <PersonCard person={person} giveImportance={featured} />
+            <FeaturedPerson person={person} />
             {person.personalStory !== null && (
               <div class="mx-auto max-w-fit mb-12">
                 <Link size="xl" href={`${kebabCase(person.fullName)}`}>
@@ -54,11 +54,7 @@ const {
           </div>
         ))
       :
-      personGroup.members.map((person) => (
-        <Card disableBorder={true} additiveClasses={["flex-1 p-4"]}>
-          <PersonCard person={person} giveImportance={featured} />
-        </Card>
-      ))
+      personGroup.members.map((person) => <Person person={person} />)
     }
   </div>
 </div>

--- a/src/ui/PersonGroupBlock.astro
+++ b/src/ui/PersonGroupBlock.astro
@@ -6,6 +6,7 @@ import EmphasizedEllipsisText from "./primitives/EmphasizedEllipsisText.astro";
 import Heading from "./primitives/Heading.astro";
 import Link from "./primitives/Link.astro";
 import TextBlock from "./typography/TextBlock.astro";
+import Card from "./primitives/Card.astro";
 
 interface Props {
   personGroup: PersonGroup;
@@ -22,7 +23,7 @@ const {
 } = Astro.props;
 ---
 
-<div>
+<div class:list={["sm:p-3 lg:p-6"]}>
   {
     showGroupName && (
       <Heading as="h3" size="xl2">
@@ -31,18 +32,33 @@ const {
     )
   }
   {showGroupDescription && <TextBlock>{personGroup.description}</TextBlock>}
-  {
-    personGroup.members.map((person) => (
-      <>
-        <PersonCard person={person} />
-        {person.personalStory !== null && (
-          <div class="mx-auto max-w-fit mb-12">
-            <Link size="xl" href={`${kebabCase(person.fullName)}`}>
-              <EmphasizedEllipsisText text="Read More" />
-            </Link>
+  <div class:list={!featured ? [
+    "grid",
+    "sm:grid-cols-1",
+    "md:grid-cols-2",
+    "lg:grid-cols-3",
+    "gap-4"
+  ] : []}>
+    {
+      featured ? 
+        personGroup.members.map((person) => (
+          <div>
+            <PersonCard person={person} giveImportance={featured} />
+            {person.personalStory !== null && (
+              <div class="mx-auto max-w-fit mb-12">
+                <Link size="xl" href={`${kebabCase(person.fullName)}`}>
+                  <EmphasizedEllipsisText text="Read More" />
+                </Link>
+              </div>
+            )}
           </div>
-        )}
-      </>
-    ))
-  }
+        ))
+      :
+      personGroup.members.map((person) => (
+        <Card disableBorder={true}>
+          <PersonCard person={person} giveImportance={featured} />
+        </Card>
+      ))
+    }
+  </div>
 </div>

--- a/src/ui/composites/FeaturedPerson.astro
+++ b/src/ui/composites/FeaturedPerson.astro
@@ -7,6 +7,7 @@ import Subtitle from "@ui/primitives/Subtitle.astro";
 
 import linkedInImg from "../../img/linkedin.svg";
 import fallbackImg from "../../img/avatar.svg";
+import EmailIcon from "@ui/icons/EmailIcon.astro";
 
 interface Props {
   person: Person;
@@ -67,15 +68,7 @@ const avatarImage = person.avatar
             </a>
           )}
           {person.socials.email && (
-            <a href={`mailto:${person.socials.email}`} rel="nofollow">
-              <span
-                role="presentation"
-                class="text-3xl text-indigo-300/50 ml-1.5 font-semibold font-sans"
-              >
-                @
-              </span>
-              <span class="sr-only">{person.socials.email}</span>
-            </a>
+            <EmailIcon link={`mailto:${person.socials.email}`} />
           )}
         </div>
       )

--- a/src/ui/composites/FeaturedPerson.astro
+++ b/src/ui/composites/FeaturedPerson.astro
@@ -10,10 +10,9 @@ import fallbackImg from "../../img/avatar.svg";
 
 interface Props {
   person: Person;
-  giveImportance?: boolean;
 }
 
-const {person, giveImportance = true} = Astro.props;
+const {person} = Astro.props;
 
 const avatarImage = person.avatar
   ? {
@@ -27,17 +26,15 @@ const avatarImage = person.avatar
 ---
 
 <div class:list={["sm:flex"]}>
-  {giveImportance && 
-    <div class:list={["max-w-sm mx-auto", "sm:basis-1/3"]}>
-      <Card disableBorder additiveClasses={["p-3 my-3"]} fullHeight={false}>
-        <img
-          class="bg-indigo-50/50"
-          src={avatarImage.src}
-          alt={avatarImage.alt}
-        />
-      </Card>
-    </div>
-  }
+  <div class:list={["max-w-sm mx-auto", "sm:basis-1/3"]}>
+    <Card disableBorder additiveClasses={["p-3 my-3"]} fullHeight={false}>
+      <img
+        class="bg-indigo-50/50"
+        src={avatarImage.src}
+        alt={avatarImage.alt}
+      />
+    </Card>
+  </div>
   <div
     class:list={[
       "max-w-sm mx-auto sm:max-w-none sm:mx-3 md:mx-6",
@@ -46,10 +43,7 @@ const avatarImage = person.avatar
     ]}
   >
     <div class:list={["border-b-2 border-indigo-500/25 mb-3"]}>
-      <h1 class:list={[
-          "font-serif text-sky-800", 
-          giveImportance ? ["font-semibold text-4xl"] : ["text-2xl"]
-        ]}>
+      <h1 class:list={["font-serif text-sky-800 font-semibold text-4xl"]}>
         {person.fullName}
       </h1>
       <Subtitle class:list={"mb-2"}>{person.role}</Subtitle>

--- a/src/ui/composites/Person.astro
+++ b/src/ui/composites/Person.astro
@@ -1,0 +1,33 @@
+---
+import type { Person } from "@model/person";
+import PortableTextContentBlock from "@ui/typography/PortableTextContentBlock.astro";
+import Subtitle from "@ui/primitives/Subtitle.astro";
+
+interface Props {
+  person: Person;
+}
+
+const {person} = Astro.props;
+---
+
+<div class:list={["sm:flex"]}>
+  <div
+    class:list={[
+      "max-w-sm mx-auto sm:max-w-none sm:mx-3 md:mx-6",
+      "sm:flex-shrink sm:basis-2/3",
+      "sm:my-3",
+    ]}
+  >
+    <div class:list={["border-b-2 border-indigo-500/25 mb-3"]}>
+      <h1 class:list={["font-serif text-sky-800 text-2xl"]}>
+        {person.fullName}
+      </h1>
+      <Subtitle class:list={"mb-2"}>{person.role}</Subtitle>
+    </div>
+    {
+      person.shortBio && (
+        <PortableTextContentBlock portableText={person.shortBio} />
+      )
+    }
+  </div>
+</div>

--- a/src/ui/composites/PersonCard.astro
+++ b/src/ui/composites/PersonCard.astro
@@ -10,14 +10,15 @@ import fallbackImg from "../../img/avatar.svg";
 
 interface Props {
   person: Person;
+  giveImportance?: boolean;
 }
 
-const props = Astro.props;
+const {person, giveImportance = true} = Astro.props;
 
-const avatarImage = props.person.avatar
+const avatarImage = person.avatar
   ? {
-      src: getImageUrlBuilder(props.person.avatar).width(640).height(640).url(),
-      alt: `Profile photo of ${props.person.fullName}`,
+      src: getImageUrlBuilder(person.avatar).width(640).height(640).url(),
+      alt: `Profile photo of ${person.fullName}`,
     }
   : {
       src: fallbackImg.src,
@@ -26,15 +27,17 @@ const avatarImage = props.person.avatar
 ---
 
 <div class:list={["sm:flex"]}>
-  <div class:list={["max-w-sm mx-auto", "sm:basis-1/3"]}>
-    <Card disableBorder additiveClasses={["p-3 my-3"]} fullHeight={false}>
-      <img
-        class="bg-indigo-50/50"
-        src={avatarImage.src}
-        alt={avatarImage.alt}
-      />
-    </Card>
-  </div>
+  {giveImportance && 
+    <div class:list={["max-w-sm mx-auto", "sm:basis-1/3"]}>
+      <Card disableBorder additiveClasses={["p-3 my-3"]} fullHeight={false}>
+        <img
+          class="bg-indigo-50/50"
+          src={avatarImage.src}
+          alt={avatarImage.alt}
+        />
+      </Card>
+    </div>
+  }
   <div
     class:list={[
       "max-w-sm mx-auto sm:max-w-none sm:mx-3 md:mx-6",
@@ -43,38 +46,41 @@ const avatarImage = props.person.avatar
     ]}
   >
     <div class:list={["border-b-2 border-indigo-500/25 mb-3"]}>
-      <h1 class:list={["font-serif text-sky-800 font-semibold text-4xl"]}>
-        {props.person.fullName}
+      <h1 class:list={[
+          "font-serif text-sky-800", 
+          giveImportance ? ["font-semibold text-4xl"] : ["text-2xl"]
+        ]}>
+        {person.fullName}
       </h1>
-      <Subtitle class:list={"mb-2"}>{props.person.role}</Subtitle>
+      <Subtitle class:list={"mb-2"}>{person.role}</Subtitle>
     </div>
     {
-      props.person.shortBio && (
-        <PortableTextContentBlock portableText={props.person.shortBio} />
+      person.shortBio && (
+        <PortableTextContentBlock portableText={person.shortBio} />
       )
     }
     {
-      props.person.socials && (
+      person.socials && (
         <div class="flex mt-3">
-          {props.person.socials.linkedIn && (
+          {person.socials.linkedIn && (
             <a
-              href={props.person.socials.linkedIn}
+              href={person.socials.linkedIn}
               rel="nofollow"
               class="block"
             >
               <img src={linkedInImg.src} class="w-10 h-10 inline-block" />
-              <span class="sr-only">{props.person.socials.linkedIn}</span>
+              <span class="sr-only">{person.socials.linkedIn}</span>
             </a>
           )}
-          {props.person.socials.email && (
-            <a href={`mailto:${props.person.socials.email}`} rel="nofollow">
+          {person.socials.email && (
+            <a href={`mailto:${person.socials.email}`} rel="nofollow">
               <span
                 role="presentation"
                 class="text-3xl text-indigo-300/50 ml-1.5 font-semibold font-sans"
               >
                 @
               </span>
-              <span class="sr-only">{props.person.socials.email}</span>
+              <span class="sr-only">{person.socials.email}</span>
             </a>
           )}
         </div>

--- a/src/ui/icons/EmailIcon.astro
+++ b/src/ui/icons/EmailIcon.astro
@@ -1,0 +1,20 @@
+---
+interface Props {
+  link: string;
+  iconClasses?: Array<string>;
+}
+
+const { link, iconClasses = [] } = Astro.props;
+
+---
+
+<a
+  href={link}
+  rel="nofollow"
+  class="block"
+>
+  <svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="rgb(209, 210, 243)" class:list={iconClasses.length == 0 ? "w-10 h-10 inline-block" : iconClasses}>
+    <path stroke-linecap="round" stroke-linejoin="round" d="M16.5 12a4.5 4.5 0 1 1-9 0 4.5 4.5 0 0 1 9 0Zm0 0c0 1.657 1.007 3 2.25 3S21 13.657 21 12a9 9 0 1 0-2.636 6.364M16.5 12V8.25" />
+  </svg>
+  <span class="sr-only">{link}</span>
+</a>

--- a/src/ui/primitives/Card.astro
+++ b/src/ui/primitives/Card.astro
@@ -32,7 +32,7 @@ const borderColorClass = props.resourceType
 >
   <div
     class:list={[
-      "border border-b-0 border-slate-100",
+      "border-b-0 border-slate-100",
       props.fullHeight ? "h-full" : null,
     ]}
   >


### PR DESCRIPTION
### Changes:
Used tailwind's grid functionality to display non-featured people. Displayed 3 people on large screens and above, 2 people on medium screens, and one person on small screens. This was achieved through using the `featured` prop, and adding the `giveImportance` prop to `PersonCard`

### Screenshots:
Large screen:
![image](https://github.com/user-attachments/assets/63b11c42-6475-435f-a365-d33cb8a54425)

Medium Screen:
![image](https://github.com/user-attachments/assets/9104277a-baf2-4c8d-9bc6-cca5d00403dd)

Small Screen:
![image](https://github.com/user-attachments/assets/514a2ab8-cb46-4837-9d2c-91062f861bcd)

Closes #133 